### PR TITLE
Rolling back Graph Upgrades

### DIFF
--- a/OOFScheduling/Form1.cs
+++ b/OOFScheduling/Form1.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.Graph.Models;
+﻿using Microsoft.Graph;
 using Microsoft.Win32;
 using Newtonsoft.Json;
 using System;
@@ -402,7 +402,7 @@ namespace OOFScheduling
             toolStripStatusLabel1.Text = DateTime.Now.ToString() + " - Sending to O365";
 
             //need to convert the times from local datetime to DateTimeTimeZone and UTC
-            Microsoft.Graph.Models.DateTimeTimeZone oofStart = new DateTimeTimeZone { DateTime = StartTime.ToUniversalTime().ToString("u").Replace("Z", ""), TimeZone = "UTC" };
+            DateTimeTimeZone oofStart = new DateTimeTimeZone { DateTime = StartTime.ToUniversalTime().ToString("u").Replace("Z", ""), TimeZone = "UTC" };
             DateTimeTimeZone oofEnd = new DateTimeTimeZone { DateTime = EndTime.ToUniversalTime().ToString("u").Replace("Z", ""), TimeZone = "UTC" };
 
             //create local OOF object

--- a/OOFScheduling/O365.cs
+++ b/OOFScheduling/O365.cs
@@ -260,7 +260,7 @@ namespace OOFScheduling
             {
 
 #if !NOOOF
-                Microsoft.Graph.Models.MailboxSettings mbox = new Microsoft.Graph.Models.MailboxSettings();
+                Microsoft.Graph.MailboxSettings mbox = new Microsoft.Graph.MailboxSettings();
                 mbox.AutomaticRepliesSetting = OOF;
 
                 var request = new System.Net.Http.HttpRequestMessage(method, UrlCombine(_graphAPIEndpoint, url));

--- a/OOFScheduling/O365.cs
+++ b/OOFScheduling/O365.cs
@@ -241,7 +241,7 @@ namespace OOFScheduling
         /// <param name="url">The URL</param>
         /// <param name="token">The token</param>
         /// <returns>String containing the results of the GET operation</returns>
-        public static async Task<System.Net.Http.HttpResponseMessage> PatchHttpContentWithToken(string url, Microsoft.Graph.Models.AutomaticRepliesSetting OOF)
+        public static async Task<System.Net.Http.HttpResponseMessage> PatchHttpContentWithToken(string url, Microsoft.Graph.AutomaticRepliesSetting OOF)
         {
             OOFSponder.Logger.Info(OOFSponderInsights.CurrentMethod());
 

--- a/OOFScheduling/OOFSponder.csproj
+++ b/OOFScheduling/OOFSponder.csproj
@@ -43,7 +43,7 @@
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
     <OutputPath>bin\Debug\</OutputPath>
-    <DefineConstants>TRACE;DEBUG;FASTLOOP</DefineConstants>
+    <DefineConstants>TRACE;DEBUG;NOOOF;FASTOOF</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>

--- a/OOFScheduling/OOFSponder.csproj
+++ b/OOFScheduling/OOFSponder.csproj
@@ -43,7 +43,7 @@
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
     <OutputPath>bin\Debug\</OutputPath>
-    <DefineConstants>TRACE;DEBUG;NOOOF;FASTOOF</DefineConstants>
+    <DefineConstants>TRACE;DEBUG</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>

--- a/OOFScheduling/OOFSponder.csproj
+++ b/OOFScheduling/OOFSponder.csproj
@@ -206,25 +206,25 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.ApplicationInsights">
-      <Version>2.22.0</Version>
+      <Version>2.16.0</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.Exchange.WebServices">
       <Version>2.2.0</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.Graph">
-      <Version>5.41.0</Version>
+      <Version>3.21.0</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.Identity.Client">
-      <Version>4.59.0</Version>
+      <Version>4.24.0</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.Identity.Client.Extensions.Msal">
-      <Version>4.59.0</Version>
+      <Version>2.16.7</Version>
     </PackageReference>
     <PackageReference Include="Newtonsoft.Json">
-      <Version>13.0.3</Version>
+      <Version>12.0.3</Version>
     </PackageReference>
     <PackageReference Include="System.Diagnostics.DiagnosticSource">
-      <Version>8.0.0</Version>
+      <Version>5.0.0</Version>
     </PackageReference>
     <PackageReference Include="System.Net.Http">
       <Version>4.3.4</Version>


### PR DESCRIPTION
Validated that upgrading to the latest and greatest Graph library breaks the ability to update OOF. Rather than fighting, just don't upgrade that piece